### PR TITLE
fix: GitHub Actions id-token権限の追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,7 @@ jobs:
       issues: write
       pull-requests: write
       actions: write
+      id-token: write
       
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Claude Code ActionのOIDCトークン取得エラーを解決するため、id-token: write権限を追加